### PR TITLE
Update spi-device to ^3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   "license": "BSD 3-Clause License",
   "dependencies": {
     "crc": "^3.4.0",
-    "spi-device": "^2.0.0"
+    "spi-device": "^3.1.2"
   }
 }


### PR DESCRIPTION
I ran into https://github.com/fivdi/spi-device/issues/21 when trying to install `node-red-contrib-monarco-hat` on a Pi2 running Devuan Daedalus with kernel 5.18.12-v8. With [some help](https://discourse.nodered.org/t/scared-of-upgrading-ancient-node-red-1-1-3-to-3-x/65411/30?u=clickworkorange) I managed to resolve this by upgrading the `monarco-hat-driver-nodejs` `spi-device` dependency to 3.1.2 - at least in so far as it allowed me to install `node-red-contrib-monarco-hat` without errors. I am unable to test this on the actual hardware however, since the only Monarco-Hat I have to hand is in use. Looking at [the spi-device history](https://github.com/fivdi/spi-device/blob/master/History.md) I would bet this could be merged without issue. 